### PR TITLE
fix-signature-generation-logic-for-signQuery

### DIFF
--- a/examples/example3.js
+++ b/examples/example3.js
@@ -4,7 +4,7 @@ const { sign } = require("@gofynd/fp-signature")
 const requestToSign = {
   method: "GET",
   host: "api.fynd.com",
-  path: "/service/application/configuration/v1.0/application",
+  path: "/service/application/configuration/v1.0/application?x-fp-signature=v1.1%3A38555f0f81ac778036a0d2eeb53c872dc05ca8e5ad133d24e8e197994fbc7dac&x-fp-date=20231129T121756Z",
   headers: {
     Authorization: "Bearer <authorizationToken>",
     "x-currency-code": "INR"

--- a/src/RequestSigner.ts
+++ b/src/RequestSigner.ts
@@ -252,6 +252,8 @@ export default class RequestSigner {
 
     if (queryIx >= 0) {
       query = querystring.parse(path.slice(queryIx + 1));
+      delete query["x-fp-signature"]
+      delete query["X-Fp-Signature"]
       path = path.slice(0, queryIx);
     }
     path = path


### PR DESCRIPTION
Ignore signature in signature generation process if it is already present in query param provided by user